### PR TITLE
Small-step interpreter in chapter 3-4 diverges unexpectedly

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,3 +3,4 @@ scalaVersion := "2.13.1"
 name := "tapl-scala"
 
 libraryDependencies += "org.scala-lang.modules" %% "scala-parser-combinators" % "1.1.2"
+libraryDependencies += "org.scalatest" %% "scalatest" % "3.1.1" % "test"

--- a/src/main/scala/tapl/arith/core.scala
+++ b/src/main/scala/tapl/arith/core.scala
@@ -3,13 +3,14 @@ package tapl.arith
 // Small-step semantics as described by Pierce
 object Evaluator {
   import Util._
+  import ArithParsers._
 
   private def eval1(t: Term): Term = t match {
     case TmIf(TmTrue, t2, t3) =>
       t2
     case TmIf(TmFalse, t2, t3) =>
       t3
-    case TmIf(t1, t2, t3) =>
+    case TmIf(t1, t2, t3) if !isVal(t1) =>
       val t11 = eval1(t1)
       TmIf(t11, t2, t3)
     case TmSucc(t1) =>
@@ -19,14 +20,14 @@ object Evaluator {
       TmZero
     case TmPred(TmSucc(nv1)) if isNumericVal(nv1) =>
       nv1
-    case TmPred(t1) =>
+    case TmPred(t1) if !isVal(t1) =>
       val t2 = eval1(t1)
       TmPred(t2)
     case TmIsZero(TmZero) =>
       TmTrue
     case TmIsZero(TmSucc(nv1)) if isNumericVal(nv1) =>
       TmFalse
-    case TmIsZero(t1) =>
+    case TmIsZero(t1) if !isVal(t1) =>
       val t2 = eval(t1)
       TmIsZero(t2)
     case _ => throw new NoRuleApplies(t)
@@ -41,6 +42,7 @@ object Evaluator {
       case _: NoRuleApplies             => throw new NoRuleApplies(t)
     }
 
+  def eval(t: String) : Term = eval(ArithParsers.parseTerm(t))
 }
 
 // This is solution to the Exercise 3.5.17
@@ -83,6 +85,8 @@ object BigStepEvaluator {
       }
     case _ => throw new NoRuleApplies(t)
   }
+
+  def eval(t: String) : Term = eval(ArithParsers.parseTerm(t))
 }
 
 object Util {

--- a/src/main/scala/tapl/arith/parser.scala
+++ b/src/main/scala/tapl/arith/parser.scala
@@ -41,4 +41,9 @@ object ArithParsers extends StandardTokenParsers with ImplicitConversions {
     case t if t.successful => t.get
     case t                 => sys.error(t.toString)
   }
+
+  def parseTerm(s: String): Term = phrase(term)(new lexical.Scanner(s)) match {
+    case t if t.successful => t.get
+    case t                 => sys.error(t.toString)
+  }
 }

--- a/src/test/scala/tapl/arith/ArithTest.scala
+++ b/src/test/scala/tapl/arith/ArithTest.scala
@@ -1,0 +1,40 @@
+package tapl.arith
+
+import org.scalatest._
+
+import Evaluator._
+
+class ArithTest extends FlatSpec with org.scalatest.matchers.should.Matchers {
+  def testInterpreter(name: String, eval: String => Term): Unit = {
+    "A %s interpreter for arithmetic expressions".format(name) should "not reduce values any further" in {
+      val progs = List("0", "succ 0", "succ (succ 0)", "true", "false")
+      for(prog <- progs)
+        eval(prog) should be (parse(prog))
+    }
+
+    it should "reduce boolean expressions to a value" in {
+      eval("iszero 0") should be (parse("true"))
+      eval("iszero (succ 0)") should be (parse("false"))
+      eval("if (iszero 0) then true else false") should be (parse("true"))
+      eval("if (iszero (succ 0)) then true else false") should be (parse("false"))
+    }
+
+    it should "reduce numeric expressions to a value" in {
+      eval("pred (succ 0)") should be (parse("0"))
+      eval("pred 0") should be (parse("0"))
+      eval("succ (pred 0)") should be (parse("succ 0"))
+    }
+
+    it should "get stuck on ill-typed terms" in {
+      a [NoRuleApplies] should be thrownBy { eval("succ true") }
+      a [NoRuleApplies] should be thrownBy { eval("pred true") }
+      a [NoRuleApplies] should be thrownBy { eval("iszero true") }
+      a [NoRuleApplies] should be thrownBy { eval("if 0 then true else false") }
+    }
+  }
+
+  testInterpreter("small-step", Evaluator.eval)
+  testInterpreter("big-step", BigStepEvaluator.eval)
+
+  private def parse(prog: String) = ArithParsers.parseTerm(prog)
+}


### PR DESCRIPTION
Hi,

I added some tests for the interpreters in chapter 3-4 of the book. In this process I found a small issue with the small-step interpreter. In particular, it does not terminate for expressions such as `iszero false`, because of this small-step transition:
```scala
 case TmIsZero(t1) =>
      val t2 = eval(t1)
      TmIsZero(t2)
```
I fixed this issue by requiring that `t1` is not a value. Then the interpreter throws an `NoRulesApply` exception as expected.

Regards,
Sven