### PR TITLE
update and fix locally scala-parser-combinators

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,5 +4,5 @@ name := "tapl-scala"
 
 scalacOptions ++= Seq("-deprecation", "-feature")
 
-libraryDependencies += ("org.scala-lang.modules" %% "scala-parser-combinators" % "1.2.0-M2").withDottyCompat(scalaVersion.value)
+libraryDependencies += ("org.scala-lang.modules" %% "scala-parser-combinators" % "1.2.0-M2")
 libraryDependencies += "org.scalatest" %% "scalatest" % "3.2.5" % "test"

--- a/src/main/scala/tapl/arith/parser.scala
+++ b/src/main/scala/tapl/arith/parser.scala
@@ -40,7 +40,8 @@ object ArithParsers extends StandardTokenParsers with ImplicitConversions {
       case _ => TmSucc(num(x - 1))
     }
 
-  private def eof: Parser[String] = elem("<eof>", _ == lexical.EOF) ^^ { _.chars }
+  private def eof: Parser[String] =
+    elem("<eof>", _ == lexical.EOF) ^^ { _.chars }
 
   def input(s: String): List[Command] =
     phrase(topLevel)(new lexical.Scanner(s)) match {

--- a/src/main/scala/tapl/bot/parser.scala
+++ b/src/main/scala/tapl/bot/parser.scala
@@ -1,8 +1,8 @@
 package tapl.bot
 
 import scala.util.parsing.combinator.ImplicitConversions
-import scala.util.parsing.combinator.PackratParsers
 import scala.util.parsing.combinator.syntactical.StandardTokenParsers
+import util.PackratParsers
 
 object BotParsers extends StandardTokenParsers with PackratParsers with ImplicitConversions {
   import Binding._

--- a/src/main/scala/tapl/bot/parser.scala
+++ b/src/main/scala/tapl/bot/parser.scala
@@ -10,62 +10,22 @@ object BotParsers extends StandardTokenParsers with PackratParsers with Implicit
   import Term._
   import Ty._
 
-  lexical.reserved ++= Seq(
-    "lambda",
-    "Bool",
-    "true",
-    "false",
-    "if",
-    "then",
-    "else",
-    "Nat",
-    "String",
-    "Unit",
-    "Float",
-    "unit",
-    "case",
-    "let",
-    "in",
-    "succ",
-    "pred",
-    "as",
-    "of",
-    "fix",
-    "iszero",
-    "letrec",
-    "_",
-    "Top",
-    "Bot",
-  )
-  lexical.delimiters ++= Seq(
-    "(",
-    ")",
-    ";",
-    "/",
-    ".",
-    ":",
-    "->",
-    "=",
-    "<",
-    ">",
-    "{",
-    "}",
-    "=>",
-    "==>",
-    ",",
-    "|",
-  )
+  lexical.reserved ++=
+    Seq("lambda", "Top", "Bot")
+  lexical.delimiters ++=
+    Seq("(", ")", ";", ".", ":", "->")
 
-  // lower-case identifier
-  lazy val lcid: PackratParser[String] = ident ^? { case id if id.charAt(0).isLower => id }
-  // upper-case identifier
-  lazy val ucid: PackratParser[String] = ident ^? { case id if id.charAt(0).isUpper => id }
-  lazy val eof: PackratParser[String] = elem("<eof>", _ == lexical.EOF) ^^ { _.chars }
+  private lazy val lcid: PackratParser[String] =
+    ident ^? { case id if id.charAt(0).isLower => id }
+  private lazy val ucid: PackratParser[String] =
+    ident ^? { case id if id.charAt(0).isUpper => id }
+  private lazy val eof: PackratParser[String] =
+    elem("<eof>", _ == lexical.EOF) ^^ { _.chars }
 
   type Res[A] = Context => A
   type Res1[A] = Context => (A, Context)
 
-  lazy val topLevel: PackratParser[Res1[List[Command]]] =
+  private lazy val topLevel: PackratParser[Res1[List[Command]]] =
     ((command <~ ";") ~ topLevel) ^^ {
       case f ~ g =>
         (ctx: Context) =>
@@ -74,36 +34,27 @@ object BotParsers extends StandardTokenParsers with PackratParsers with Implicit
           (cmd1 :: cmds, ctx2)
     } | success { (ctx: Context) => (List(), ctx) }
 
-  lazy val command: PackratParser[Res1[Command]] =
+  private lazy val command: PackratParser[Res1[Command]] =
     lcid ~ binder ^^ { case id ~ bind => (ctx: Context) => (Bind(id, bind(ctx)), ctx.addName(id)) } |
       term ^^ { t => (ctx: Context) =>
         val t1 = t(ctx); (Eval(t1), ctx)
       }
 
-  lazy val binder: Parser[Context => Binding] =
+  private lazy val binder: PackratParser[Res[Binding]] =
     ":" ~> typ ^^ { t => (ctx: Context) => VarBind(t(ctx)) }
 
-  lazy val typ: PackratParser[Res[Ty]] = arrowType
-  lazy val aType: PackratParser[Res[Ty]] =
+  private lazy val typ: PackratParser[Res[Ty]] =
+    arrowType
+  private lazy val aType: PackratParser[Res[Ty]] =
     "(" ~> typ <~ ")" |
       "Bot" ^^ { _ => (ctx: Context) => TyBot } |
       "Top" ^^ { _ => (ctx: Context) => TyTop }
 
-  lazy val fieldTypes: PackratParser[Res[List[(String, Ty)]]] =
-    repsep(fieldType, ",") ^^ { fs => (ctx: Context) =>
-      fs.zipWithIndex.map { case (ft, i) => ft(ctx, i + 1) }
-    }
-
-  lazy val fieldType: PackratParser[(Context, Int) => (String, Ty)] =
-    lcid ~ (":" ~> typ) ^^ { case id ~ ty => (ctx: Context, i: Int) => (id, ty(ctx)) } |
-      typ ^^ { ty => (ctx: Context, i: Int) => (i.toString, ty(ctx)) }
-
-  lazy val arrowType: PackratParser[Res[Ty]] =
+  private lazy val arrowType: PackratParser[Res[Ty]] =
     (aType <~ "->") ~ arrowType ^^ { case t1 ~ t2 => (ctx: Context) => TyArr(t1(ctx), t2(ctx)) } |
       aType
 
-  // TERMS
-  lazy val term: PackratParser[Res[Term]] =
+  private lazy val term: PackratParser[Res[Term]] =
     appTerm |
       ("lambda" ~> lcid) ~ (":" ~> typ) ~ ("." ~> term) ^^ {
         case v ~ ty ~ t => (ctx: Context) => TmAbs(v, ty(ctx), t(ctx.addName(v)))
@@ -111,20 +62,20 @@ object BotParsers extends StandardTokenParsers with PackratParsers with Implicit
       ("lambda" ~ "_") ~> (":" ~> typ) ~ ("." ~> term) ^^ {
         case ty ~ t => (ctx: Context) => TmAbs("_", ty(ctx), t(ctx.addName("_")))
       }
-  lazy val appTerm: PackratParser[Res[Term]] =
+  private lazy val appTerm: PackratParser[Res[Term]] =
     appTerm ~ aTerm ^^ { case t1 ~ t2 => (ctx: Context) => TmApp(t1(ctx), t2(ctx)) } |
       aTerm
 
-  lazy val aTerm: PackratParser[Res[Term]] =
+  private lazy val aTerm: PackratParser[Res[Term]] =
     "(" ~> term <~ ")" |
       lcid ^^ { i => (ctx: Context) => TmVar(ctx.name2index(i), ctx.length) }
 
-  lazy val phraseTopLevel: PackratParser[Res1[List[Command]]] = phrase(topLevel)
+  private lazy val phraseTopLevel: PackratParser[Res1[List[Command]]] =
+    phrase(topLevel)
 
-  def input(s: String) =
+  def input(s: String): Res1[List[Command]] =
     phraseTopLevel(new lexical.Scanner(s)) match {
       case t if t.successful => t.get
       case t                 => sys.error(t.toString)
     }
-
 }

--- a/src/main/scala/tapl/equirec/parser.scala
+++ b/src/main/scala/tapl/equirec/parser.scala
@@ -1,8 +1,8 @@
 package tapl.equirec
 
 import scala.util.parsing.combinator.ImplicitConversions
-import scala.util.parsing.combinator.PackratParsers
 import scala.util.parsing.combinator.syntactical.StandardTokenParsers
+import util.PackratParsers
 
 object EquirecParsers extends StandardTokenParsers with PackratParsers with ImplicitConversions {
   import Binding._

--- a/src/main/scala/tapl/fullequirec/parser.scala
+++ b/src/main/scala/tapl/fullequirec/parser.scala
@@ -1,8 +1,8 @@
 package tapl.fullequirec
 
 import scala.util.parsing.combinator.ImplicitConversions
-import scala.util.parsing.combinator.PackratParsers
 import scala.util.parsing.combinator.syntactical.StandardTokenParsers
+import util.PackratParsers
 
 object FullEquirecParsers
     extends StandardTokenParsers

--- a/src/main/scala/tapl/fullerror/parser.scala
+++ b/src/main/scala/tapl/fullerror/parser.scala
@@ -1,8 +1,8 @@
 package tapl.fullerror
 
 import scala.util.parsing.combinator.ImplicitConversions
-import scala.util.parsing.combinator.PackratParsers
 import scala.util.parsing.combinator.syntactical.StandardTokenParsers
+import util.PackratParsers
 
 object FullErrorParsers extends StandardTokenParsers with PackratParsers with ImplicitConversions {
   import Binding._

--- a/src/main/scala/tapl/fullfomsub/parser.scala
+++ b/src/main/scala/tapl/fullfomsub/parser.scala
@@ -1,8 +1,8 @@
 package tapl.fullfomsub
 
 import scala.util.parsing.combinator.ImplicitConversions
-import scala.util.parsing.combinator.PackratParsers
 import scala.util.parsing.combinator.syntactical.StandardTokenParsers
+import util.PackratParsers
 
 import Syntax._
 

--- a/src/main/scala/tapl/fullfomsubref/parser.scala
+++ b/src/main/scala/tapl/fullfomsubref/parser.scala
@@ -1,8 +1,8 @@
 package tapl.fullfomsubref
 
 import scala.util.parsing.combinator.ImplicitConversions
-import scala.util.parsing.combinator.PackratParsers
 import scala.util.parsing.combinator.syntactical.StandardTokenParsers
+import util.PackratParsers
 import Syntax._
 
 object FullFomSubRefParsers

--- a/src/main/scala/tapl/fullfsub/parser.scala
+++ b/src/main/scala/tapl/fullfsub/parser.scala
@@ -1,8 +1,8 @@
 package tapl.fullfsub
 
 import scala.util.parsing.combinator.ImplicitConversions
-import scala.util.parsing.combinator.PackratParsers
 import scala.util.parsing.combinator.syntactical.StandardTokenParsers
+import util.PackratParsers
 
 object FullFSubParsers extends StandardTokenParsers with PackratParsers with ImplicitConversions {
   import Binding._

--- a/src/main/scala/tapl/fullisorec/parser.scala
+++ b/src/main/scala/tapl/fullisorec/parser.scala
@@ -1,8 +1,8 @@
 package tapl.fullisorec
 
 import scala.util.parsing.combinator.ImplicitConversions
-import scala.util.parsing.combinator.PackratParsers
 import scala.util.parsing.combinator.syntactical.StandardTokenParsers
+import util.PackratParsers
 
 object FullIsorecParsers extends StandardTokenParsers with PackratParsers with ImplicitConversions {
   import Binding._

--- a/src/main/scala/tapl/fullomega/parser.scala
+++ b/src/main/scala/tapl/fullomega/parser.scala
@@ -1,8 +1,8 @@
 package tapl.fullomega
 
 import scala.util.parsing.combinator.ImplicitConversions
-import scala.util.parsing.combinator.PackratParsers
 import scala.util.parsing.combinator.syntactical.StandardTokenParsers
+import util.PackratParsers
 
 object FullOmegaParsers extends StandardTokenParsers with PackratParsers with ImplicitConversions {
   import Binding._

--- a/src/main/scala/tapl/fullpoly/parser.scala
+++ b/src/main/scala/tapl/fullpoly/parser.scala
@@ -1,8 +1,8 @@
 package tapl.fullpoly
 
 import scala.util.parsing.combinator.ImplicitConversions
-import scala.util.parsing.combinator.PackratParsers
 import scala.util.parsing.combinator.syntactical.StandardTokenParsers
+import util.PackratParsers
 
 object FullPolyParsers extends StandardTokenParsers with PackratParsers with ImplicitConversions {
   import Binding._

--- a/src/main/scala/tapl/fullrecon/parser.scala
+++ b/src/main/scala/tapl/fullrecon/parser.scala
@@ -1,8 +1,8 @@
 package tapl.fullrecon
 
 import scala.util.parsing.combinator.ImplicitConversions
-import scala.util.parsing.combinator.PackratParsers
 import scala.util.parsing.combinator.syntactical.StandardTokenParsers
+import util.PackratParsers
 
 object FullReconParsers extends StandardTokenParsers with PackratParsers with ImplicitConversions {
   import Binding._

--- a/src/main/scala/tapl/fullref/parser.scala
+++ b/src/main/scala/tapl/fullref/parser.scala
@@ -1,8 +1,8 @@
 package tapl.fullref
 
 import scala.util.parsing.combinator.ImplicitConversions
-import scala.util.parsing.combinator.PackratParsers
 import scala.util.parsing.combinator.syntactical.StandardTokenParsers
+import util.PackratParsers
 
 object FullRefParsers extends StandardTokenParsers with PackratParsers with ImplicitConversions {
   import Binding._

--- a/src/main/scala/tapl/fullsimple/parser.scala
+++ b/src/main/scala/tapl/fullsimple/parser.scala
@@ -1,8 +1,8 @@
 package tapl.fullsimple
 
 import scala.util.parsing.combinator.ImplicitConversions
-import scala.util.parsing.combinator.PackratParsers
 import scala.util.parsing.combinator.syntactical.StandardTokenParsers
+import util.PackratParsers
 
 object FullSimpleParsers extends StandardTokenParsers with PackratParsers with ImplicitConversions {
   import Binding._

--- a/src/main/scala/tapl/fullsub/parser.scala
+++ b/src/main/scala/tapl/fullsub/parser.scala
@@ -1,8 +1,8 @@
 package tapl.fullsub
 
 import scala.util.parsing.combinator.ImplicitConversions
-import scala.util.parsing.combinator.PackratParsers
 import scala.util.parsing.combinator.syntactical.StandardTokenParsers
+import util.PackratParsers
 
 object FullSubParsers extends StandardTokenParsers with PackratParsers with ImplicitConversions {
   import Binding._

--- a/src/main/scala/tapl/fulluntyped/parser.scala
+++ b/src/main/scala/tapl/fulluntyped/parser.scala
@@ -1,8 +1,8 @@
 package tapl.fulluntyped
 
 import scala.util.parsing.combinator.ImplicitConversions
-import scala.util.parsing.combinator.PackratParsers
 import scala.util.parsing.combinator.syntactical.StandardTokenParsers
+import util.PackratParsers
 
 object FullUntypedParsers
     extends StandardTokenParsers

--- a/src/main/scala/tapl/rcdsubbot/parser.scala
+++ b/src/main/scala/tapl/rcdsubbot/parser.scala
@@ -1,8 +1,8 @@
 package tapl.rcdsubbot
 
 import scala.util.parsing.combinator.ImplicitConversions
-import scala.util.parsing.combinator.PackratParsers
 import scala.util.parsing.combinator.syntactical.StandardTokenParsers
+import util.PackratParsers
 
 object RcdSubBotParsers extends StandardTokenParsers with PackratParsers with ImplicitConversions {
   import Binding._

--- a/src/main/scala/tapl/recon/parser.scala
+++ b/src/main/scala/tapl/recon/parser.scala
@@ -1,8 +1,8 @@
 package tapl.recon
 
 import scala.util.parsing.combinator.ImplicitConversions
-import scala.util.parsing.combinator.PackratParsers
 import scala.util.parsing.combinator.syntactical.StandardTokenParsers
+import util.PackratParsers
 
 object ReconParsers extends StandardTokenParsers with PackratParsers with ImplicitConversions {
   import Binding._

--- a/src/main/scala/tapl/simplebool/parser.scala
+++ b/src/main/scala/tapl/simplebool/parser.scala
@@ -1,8 +1,8 @@
 package tapl.simplebool
 
 import scala.util.parsing.combinator.ImplicitConversions
-import scala.util.parsing.combinator.PackratParsers
 import scala.util.parsing.combinator.syntactical.StandardTokenParsers
+import util.PackratParsers
 
 object SimpleBoolParsers extends StandardTokenParsers with PackratParsers with ImplicitConversions {
   import Binding._

--- a/src/main/scala/tapl/untyped/parser.scala
+++ b/src/main/scala/tapl/untyped/parser.scala
@@ -1,8 +1,8 @@
 package tapl.untyped
 
 import scala.util.parsing.combinator.ImplicitConversions
-import scala.util.parsing.combinator.PackratParsers
 import scala.util.parsing.combinator.syntactical.StandardTokenParsers
+import util.PackratParsers
 
 // This parser is done exactly in the same way as in TAPL.
 // The oddity of this parser (elementary parsers return functions) is driven by the desire

--- a/src/main/scala/util/packrat.scala
+++ b/src/main/scala/util/packrat.scala
@@ -235,7 +235,10 @@ to update each parser involved in the recursion.
         /*
          * transformed reader
          */
-        val inMem = in.asInstanceOf[PackratReader[Elem]]
+        val inMem: PackratReader[Elem] = in match {
+          case in: PackratReader[_] => in.asInstanceOf[PackratReader[Elem]]
+          case in => new PackratReader(in)
+        }
 
         //look in the global cache if in a recursion
         val m = recall(p, inMem)

--- a/src/main/scala/util/packrat.scala
+++ b/src/main/scala/util/packrat.scala
@@ -1,0 +1,311 @@
+/*
+ * Scala (https://www.scala-lang.org)
+ *
+ * Copyright EPFL and Lightbend, Inc.
+ *
+ * Licensed under Apache License 2.0
+ * (http://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package util
+
+import scala.util.parsing.combinator.Parsers
+import scala.util.parsing.input.{ Reader, Position }
+import scala.collection.mutable
+import scala.language.implicitConversions
+
+/**
+ *  `PackratParsers` is a component that extends the parser combinators
+ *  provided by [[scala.util.parsing.combinator.Parsers]] with a memoization
+ *  facility (''Packrat Parsing'').
+ *
+ *  Packrat Parsing is a technique for implementing backtracking,
+ *  recursive-descent parsers, with the advantage that it guarantees
+ *  unlimited lookahead and a linear parse time. Using this technique,
+ *  left recursive grammars can also be accepted.
+ *
+ *  Using `PackratParsers` is very similar to using `Parsers`:
+ *   - any class/trait that extends `Parsers` (directly or through a subclass)
+ *     can mix in `PackratParsers`.
+ *     Example: `'''object''' MyGrammar '''extends''' StandardTokenParsers '''with''' PackratParsers`
+ *   - each grammar production previously declared as a `def` without formal
+ *     parameters becomes a `lazy val`, and its type is changed from
+ *     `Parser[Elem]` to `PackratParser[Elem]`.
+ *     So, for example, `'''def''' production: Parser[Int] = {...}`
+ *     becomes `'''lazy val''' production: PackratParser[Int] = {...}`
+ *   - Important: using `PackratParser`s is not an ''all or nothing'' decision.
+ *     They can be free mixed with regular `Parser`s in a single grammar.
+ *
+ *  Cached parse results are attached to the ''input'', not the grammar.
+ *  Therefore, `PackratsParser`s require a `PackratReader` as input, which
+ *  adds memoization to an underlying `Reader`. Programmers can create
+ *  `PackratReader` objects either manually, as in
+ *  `production('''new''' PackratReader('''new''' lexical.Scanner("input")))`,
+ *  but the common way should be to rely on the combinator `phrase` to wrap
+ *  a given input with a `PackratReader` if the input is not one itself.
+ *
+ * @see Bryan Ford: "Packrat Parsing: Simple, Powerful, Lazy, Linear Time." ICFP'02
+ * @see Alessandro Warth, James R. Douglass, Todd Millstein: "Packrat Parsers Can Support Left Recursion." PEPM'08
+ *
+ * @since 2.8
+ */
+
+trait PackratParsers extends Parsers {
+  /**
+   * A specialized `Reader` class that wraps an underlying `Reader`
+   * and provides memoization of parse results.
+   */
+  class PackratReader[+T](underlying: Reader[T]) extends Reader[T] { outer =>
+
+    /*
+     * caching of intermediate parse results and information about recursion
+     */
+    private[PackratParsers] val cache = mutable.HashMap.empty[(Parser[_], Position), MemoEntry[_]]
+
+    private[PackratParsers] def getFromCache[T2](p: Parser[T2]): Option[MemoEntry[T2]] = {
+      cache.get((p, pos)).asInstanceOf[Option[MemoEntry[T2]]]
+    }
+
+    private[PackratParsers] def updateCacheAndGet[T2](p: Parser[T2], w: MemoEntry[T2]): MemoEntry[T2] = {
+      cache.put((p, pos),w)
+      w
+    }
+
+    /* a cache for storing parser heads: allows to know which parser is involved
+       in a recursion*/
+    private[PackratParsers] val recursionHeads: mutable.HashMap[Position, Head] = mutable.HashMap.empty
+
+    //a stack that keeps a list of all involved rules
+    private[PackratParsers] var lrStack: List[LR] = Nil
+
+    override def source: java.lang.CharSequence = underlying.source
+    override def offset: Int = underlying.offset
+
+    def first: T = underlying.first
+    def rest: Reader[T] = new PackratReader(underlying.rest) {
+      override private[PackratParsers] val cache = outer.cache
+      override private[PackratParsers] val recursionHeads = outer.recursionHeads
+      lrStack = outer.lrStack
+    }
+
+    def pos: Position = underlying.pos
+    def atEnd: Boolean = underlying.atEnd
+  }
+
+  /**
+   *  A parser generator delimiting whole phrases (i.e. programs).
+   *
+   *  Overridden to make sure any input passed to the argument parser
+   *  is wrapped in a `PackratReader`.
+   */
+  override def phrase[T](p: Parser[T]) = {
+    val q = super.phrase(p)
+    new PackratParser[T] {
+      def apply(in: Input) = in match {
+        case in: PackratReader[_] => q(in)
+        case in => q(new PackratReader(in))
+      }
+    }
+  }
+
+  private def getPosFromResult(r: ParseResult[_]): Position = r.next.pos
+
+  // auxiliary data structures
+
+  private case class MemoEntry[+T](var r: Either[LR,ParseResult[_]]){
+    def getResult: ParseResult[T] = r match {
+      case Left(LR(res,_,_)) => res.asInstanceOf[ParseResult[T]]
+      case Right(res) => res.asInstanceOf[ParseResult[T]]
+    }
+  }
+
+  private case class LR(var seed: ParseResult[_], var rule: Parser[_], var head: Option[Head]){
+    def getPos: Position = getPosFromResult(seed)
+  }
+
+  private case class Head(var headParser: Parser[_], var involvedSet: List[Parser[_]], var evalSet: List[Parser[_]]){
+    def getHead = headParser
+  }
+
+  /**
+   * The root class of packrat parsers.
+   */
+  abstract class PackratParser[+T] extends super.Parser[T]
+
+  /**
+   * Implicitly convert a parser to a packrat parser.
+   * The conversion is triggered by giving the appropriate target type:
+   * {{{
+   *   val myParser: PackratParser[MyResult] = aParser
+   * }}} */
+  implicit def parser2packrat[T](p: => super.Parser[T]): PackratParser[T] = {
+    lazy val q = p
+    memo(super.Parser {in => q(in)})
+  }
+
+  /*
+   * An unspecified function that is called when a packrat reader is applied.
+   * It verifies whether we are in the process of growing a parse or not.
+   * In the former case, it makes sure that rules involved in the recursion are evaluated.
+   * It also prevents non-involved rules from getting evaluated further
+   */
+  private def recall(p: super.Parser[_], in: PackratReader[Elem]): Option[MemoEntry[_]] = {
+    val cached = in.getFromCache(p)
+    val head = in.recursionHeads.get(in.pos)
+
+    head match {
+      case None => /*no heads*/ cached
+      case Some(h@Head(hp, involved, evalSet)) => {
+        //heads found
+        if(cached.isEmpty && !(hp::involved contains p)) {
+          //Nothing in the cache, and p is not involved
+          return Some(MemoEntry(Right(Failure("dummy ",in))))
+        }
+        if(evalSet contains p){
+          //something in cache, and p is in the evalSet
+          //remove the rule from the evalSet of the Head
+          h.evalSet = h.evalSet.filterNot(_==p)
+          val tempRes = p(in)
+          //we know that cached has an entry here
+          val tempEntry: MemoEntry[_] = cached.get // match {case Some(x: MemoEntry[_]) => x}
+          //cache is modified
+          tempEntry.r = Right(tempRes)
+        }
+        cached
+      }
+    }
+  }
+
+  /*
+   * setting up the left-recursion. We have the LR for the rule head
+   * we modify the involvedSets of all LRs in the stack, till we see
+   * the current parser again
+   */
+  private def setupLR(p: Parser[_], in: PackratReader[_], recDetect: LR): Unit = {
+    if(recDetect.head.isEmpty) recDetect.head = Some(Head(p, Nil, Nil))
+
+    in.lrStack.takeWhile(_.rule != p).foreach {x =>
+      x.head = recDetect.head
+      recDetect.head.map(h => h.involvedSet = x.rule::h.involvedSet)
+    }
+  }
+
+  /*
+   * growing, if needed the recursion
+   * check whether the parser we are growing is the head of the rule.
+   * Not => no grow
+   */
+
+  /*
+   * Once the result of the recall function is known, if it is nil, then we need to store a dummy
+failure into the cache (much like in the previous listings) and compute the future parse. If it
+is not, however, this means we have detected a recursion, and we use the setupLR function
+to update each parser involved in the recursion.
+   */
+
+  private def lrAnswer[T](p: Parser[T], in: PackratReader[Elem], growable: LR): ParseResult[T] = growable match {
+    //growable will always be having a head, we can't enter lrAnswer otherwise
+    case LR(seed ,rule, Some(head)) =>
+      if(head.getHead != p) /*not head rule, so not growing*/ seed.asInstanceOf[ParseResult[T]]
+      else {
+        in.updateCacheAndGet(p, MemoEntry(Right(seed.asInstanceOf[ParseResult[T]])))
+        seed match {
+          case f@Failure(_,_) => f
+          case e@Error(_,_) => e
+          case s@Success(_,_) => /*growing*/ grow(p, in, head)
+        }
+      }
+    case _=> throw new Exception("lrAnswer with no head !!")
+  }
+
+  //p here should be strict (cannot be non-strict) !!
+  //failing left-recursive grammars: This is done by simply storing a failure if nothing is found
+
+  /**
+   * Explicitly convert a given parser to a memoizing packrat parser.
+   * In most cases, client code should avoid calling `memo` directly
+   * and rely on implicit conversion instead.
+   */
+  def memo[T](p: super.Parser[T]): PackratParser[T] = {
+    new PackratParser[T] {
+      def apply(in: Input) = {
+        /*
+         * transformed reader
+         */
+        val inMem = in.asInstanceOf[PackratReader[Elem]]
+
+        //look in the global cache if in a recursion
+        val m = recall(p, inMem)
+        m match {
+          //nothing has been done due to recall
+          case None =>
+            val base = LR(Failure("Base Failure",in), p, None)
+            inMem.lrStack = base::inMem.lrStack
+            //cache base result
+            inMem.updateCacheAndGet(p,MemoEntry(Left(base)))
+            //parse the input
+            val tempRes = p(in)
+            //the base variable has passed equality tests with the cache
+            inMem.lrStack = inMem.lrStack.tail
+            //check whether base has changed, if yes, we will have a head
+            base.head match {
+              case None =>
+                /*simple result*/
+                inMem.updateCacheAndGet(p,MemoEntry(Right(tempRes)))
+                tempRes
+              case s@Some(_) =>
+                /*non simple result*/
+                base.seed = tempRes
+                //the base variable has passed equality tests with the cache
+                val res = lrAnswer(p, inMem, base)
+                res
+            }
+
+          case Some(mEntry) => {
+            //entry found in cache
+            mEntry match {
+              case MemoEntry(Left(recDetect)) => {
+                setupLR(p, inMem, recDetect)
+                //all setupLR does is change the heads of the recursions, so the seed will stay the same
+                recDetect match {case LR(seed, _, _) => seed.asInstanceOf[ParseResult[T]]}
+              }
+              case MemoEntry(Right(res: ParseResult[_])) => res.asInstanceOf[ParseResult[T]]
+            }
+          }
+        }
+      }
+    }
+  }
+
+  private def grow[T](p: super.Parser[T], rest: PackratReader[Elem], head: Head): ParseResult[T] = {
+    //store the head into the recursionHeads
+    rest.recursionHeads.put(rest.pos, head /*match {case Head(hp,involved,_) => Head(hp,involved,involved)}*/)
+    val oldRes: ParseResult[T] = rest.getFromCache(p).get match {
+      case MemoEntry(Right(x)) => x.asInstanceOf[ParseResult[T]]
+      case _ => throw new Exception("impossible match")
+    }
+
+    //resetting the evalSet of the head of the recursion at each beginning of growth
+    head.evalSet = head.involvedSet
+    val tempRes = p(rest); tempRes match {
+      case s@Success(_,_) =>
+        if(getPosFromResult(oldRes) < getPosFromResult(tempRes)) {
+          rest.updateCacheAndGet(p, MemoEntry(Right(s)))
+          grow(p, rest, head)
+        } else {
+          //we're done with growing, we can remove data from recursion head
+          rest.recursionHeads -= rest.pos
+          rest.getFromCache(p).get match {
+            case MemoEntry(Right(x: ParseResult[_])) => x.asInstanceOf[ParseResult[T]]
+            case _ => throw new Exception("impossible match")
+          }
+        }
+      case f =>
+        rest.recursionHeads -= rest.pos
+        /*rest.updateCacheAndGet(p, MemoEntry(Right(f)));*/oldRes
+    }
+  }
+}


### PR DESCRIPTION
Updating scala-parser-combinators to 1.2.0-M2 and using dotty version reveals the bug described in scala/scala-parser-combinators#318. Working around it locally.